### PR TITLE
Only allow one method of moving the player at a time

### DIFF
--- a/Assets/Scenes/SingleScenes/SoulPlayer.cs
+++ b/Assets/Scenes/SingleScenes/SoulPlayer.cs
@@ -136,17 +136,20 @@ public partial class SoulPlayer : CharacterBody2D
 
         var mouse = GetViewport().GetMousePosition();
 
-        Velocity =
-            new Vector2(
+        if (Input.IsActionPressed("mousedown"))
+        {
+            // Move player by mouse
+            var direction = (mouse / main.camera.Zoom) - Position;
+            if (direction.Length() > 1f)
+                Velocity = direction.Normalized() * Speed;
+        }
+        else
+        {
+            // Move player by keyboard or controller
+            Velocity = new Vector2(
                 Input.GetActionStrength("ui_right") - Input.GetActionStrength("ui_left"),
                 Input.GetActionStrength("ui_down") - Input.GetActionStrength("ui_up")
             ).Normalized() * Speed;
-
-        if (Input.IsActionPressed("mousedown"))
-        {
-            var direction = (mouse / main.camera.Zoom) - Position;
-            if (direction.Length() > 1f)
-                Velocity += direction.Normalized() * Speed;
         }
 
         MoveAndSlide();


### PR DESCRIPTION
Before you would be able to combine both keyboard and mouse movements to move twice as fast. This PR restricts this so only one method may be used at a time. That is keyboard or mouse but not both.

## Before
```cs
Velocity =
    new Vector2(
        Input.GetActionStrength("ui_right") - Input.GetActionStrength("ui_left"),
        Input.GetActionStrength("ui_down") - Input.GetActionStrength("ui_up")
    ).Normalized() * Speed;

if (Input.IsActionPressed("mousedown"))
{
    var direction = (mouse / main.camera.Zoom) - Position;
    if (direction.Length() > 1f)
        Velocity += direction.Normalized() * Speed;
}
```

## After
```cs
if (Input.IsActionPressed("mousedown"))
{
    // Move player by mouse
    var direction = (mouse / main.camera.Zoom) - Position;
    if (direction.Length() > 1f)
        Velocity = direction.Normalized() * Speed;
}
else
{
    // Move player by keyboard or controller
    Velocity = new Vector2(
        Input.GetActionStrength("ui_right") - Input.GetActionStrength("ui_left"),
        Input.GetActionStrength("ui_down") - Input.GetActionStrength("ui_up")
    ).Normalized() * Speed;
}
```